### PR TITLE
Use source-map for devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,43 +4,48 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 let publicPath = "/";
 
-module.exports = {
-  mode: "development",
-  entry: {
-    index: [path.join(__dirname, "src", "index.tsx")]
-  },
-  output: {
-    path: path.join(__dirname, "dist"),
-    filename: "[name].js",
-    publicPath
-  },
-  resolve: {
-    extensions: [".js", ".jsx", ".ts", ".tsx"]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(ts|tsx|js|jsx)$/,
-        use: ["ts-loader"],
-        exclude: /node_modules/
-      }
-    ]
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: path.join(__dirname, "src", "index.html")
-    }),
-    new CopyWebpackPlugin([
-      {
-        from: "node_modules/sanitize.css/sanitize.css",
-        to: "vendor/"
-      }
-    ])
-  ],
-  devServer: {
-    contentBase: path.join(__dirname, "dist"),
-    historyApiFallback: true,
-    watchContentBase: true,
-    compress: true
-  }
+module.exports = (env, argv) => {
+  const mode = argv.mode || "development";
+
+  return {
+    mode,
+    entry: {
+      index: [path.join(__dirname, "src", "index.tsx")]
+    },
+    output: {
+      path: path.join(__dirname, "dist"),
+      filename: "[name].js",
+      publicPath
+    },
+    resolve: {
+      extensions: [".js", ".jsx", ".ts", ".tsx"]
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx|js|jsx)$/,
+          use: ["ts-loader"],
+          exclude: /node_modules/
+        }
+      ]
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: path.join(__dirname, "src", "index.html")
+      }),
+      new CopyWebpackPlugin([
+        {
+          from: "node_modules/sanitize.css/sanitize.css",
+          to: "vendor/"
+        }
+      ])
+    ],
+    devtool: mode === "development" ? "source-map" : false,
+    devServer: {
+      contentBase: path.join(__dirname, "dist"),
+      historyApiFallback: true,
+      watchContentBase: true,
+      compress: true
+    }
+  };
 };


### PR DESCRIPTION
webpack の development mode では `devtool: "eval"` が適用されるが
TypeScript のコンパイル後のコードにマッピングされてしまい不便なので
`devtool: "source-map"` を明示的に指定した